### PR TITLE
Fix common fields

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -14,8 +14,9 @@ type Alias struct {
 	MessageId    string       `json:"messageId,omitempty"`
 	PreviousId   string       `json:"previousId"`
 	UserId       string       `json:"userId"`
-	Timestamp    time.Time    `json:"timestamp,omitempty"`
+	Timestamp    time.Time    `json:"originalTimestamp,omitempty"`
 	Context      *Context     `json:"context,omitempty"`
+	Properties   Properties   `json:"properties,omitempty"`
 	Integrations Integrations `json:"integrations,omitempty"`
 	Channel      string       `json:"channel,omitempty"`
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rudderlabs/analytics-go/v4
+module github.com/bufbuild/analytics-go/v4
 
 go 1.17
 

--- a/group.go
+++ b/group.go
@@ -15,8 +15,9 @@ type Group struct {
 	AnonymousId  string       `json:"anonymousId,omitempty"`
 	UserId       string       `json:"userId,omitempty"`
 	GroupId      string       `json:"groupId"`
-	Timestamp    time.Time    `json:"timestamp,omitempty"`
+	Timestamp    time.Time    `json:"originalTimestamp,omitempty"`
 	Context      *Context     `json:"context,omitempty"`
+	Properties   Properties   `json:"properties,omitempty"`
 	Traits       Traits       `json:"traits,omitempty"`
 	Integrations Integrations `json:"integrations,omitempty"`
 	Channel      string       `json:"channel,omitempty"`

--- a/identify.go
+++ b/identify.go
@@ -14,8 +14,9 @@ type Identify struct {
 	MessageId    string       `json:"messageId,omitempty"`
 	AnonymousId  string       `json:"anonymousId,omitempty"`
 	UserId       string       `json:"userId,omitempty"`
-	Timestamp    time.Time    `json:"timestamp,omitempty"`
+	Timestamp    time.Time    `json:"originalTimestamp,omitempty"`
 	Context      *Context     `json:"context,omitempty"`
+	Properties   Properties   `json:"properties,omitempty"`
 	Traits       Traits       `json:"traits,omitempty"`
 	Integrations Integrations `json:"integrations,omitempty"`
 	Channel      string       `json:"channel,omitempty"`

--- a/page.go
+++ b/page.go
@@ -15,7 +15,7 @@ type Page struct {
 	AnonymousId  string       `json:"anonymousId,omitempty"`
 	UserId       string       `json:"userId,omitempty"`
 	Name         string       `json:"name,omitempty"`
-	Timestamp    time.Time    `json:"timestamp,omitempty"`
+	Timestamp    time.Time    `json:"originalTimestamp,omitempty"`
 	Context      *Context     `json:"context,omitempty"`
 	Properties   Properties   `json:"properties,omitempty"`
 	Integrations Integrations `json:"integrations,omitempty"`

--- a/screen.go
+++ b/screen.go
@@ -15,7 +15,7 @@ type Screen struct {
 	AnonymousId  string       `json:"anonymousId,omitempty"`
 	UserId       string       `json:"userId,omitempty"`
 	Name         string       `json:"name,omitempty"`
-	Timestamp    time.Time    `json:"timestamp,omitempty"`
+	Timestamp    time.Time    `json:"originalTimestamp,omitempty"`
 	Context      *Context     `json:"context,omitempty"`
 	Properties   Properties   `json:"properties,omitempty"`
 	Integrations Integrations `json:"integrations,omitempty"`

--- a/track.go
+++ b/track.go
@@ -15,7 +15,7 @@ type Track struct {
 	AnonymousId  string       `json:"anonymousId,omitempty"`
 	UserId       string       `json:"userId,omitempty"`
 	Event        string       `json:"event"`
-	Timestamp    time.Time    `json:"timestamp,omitempty"`
+	Timestamp    time.Time    `json:"originalTimestamp,omitempty"`
 	Context      *Context     `json:"context,omitempty"`
 	Properties   Properties   `json:"properties,omitempty"`
 	Integrations Integrations `json:"integrations,omitempty"`


### PR DESCRIPTION
Ensure each event has the `originalTimestamp` and `properties` fields as described in the Rudderstack docs for [Common Fields](https://www.rudderstack.com/docs/event-spec/standard-events/common-fields/).