### PR TITLE
fix: set sentAt to send time

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -190,6 +190,7 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Type = "alias"
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.OriginalTimestamp = makeTimestamp(m.OriginalTimestamp, ts)
+		m.SentAt = m.OriginalTimestamp
 		m.Context = makeContext(m.Context)
 		m.Channel = "server"
 		msg = m
@@ -198,6 +199,7 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Type = "group"
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.OriginalTimestamp = makeTimestamp(m.OriginalTimestamp, ts)
+		m.SentAt = m.OriginalTimestamp
 		m.AnonymousId = makeAnonymousId(m.AnonymousId)
 		m.Context = makeContext(m.Context)
 		m.Channel = "server"
@@ -207,6 +209,7 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Type = "identify"
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.OriginalTimestamp = makeTimestamp(m.OriginalTimestamp, ts)
+		m.SentAt = m.OriginalTimestamp
 		m.Context = makeContext(m.Context)
 		m.Channel = "server"
 		msg = m
@@ -215,6 +218,7 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Type = "page"
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.OriginalTimestamp = makeTimestamp(m.OriginalTimestamp, ts)
+		m.SentAt = m.OriginalTimestamp
 		m.AnonymousId = makeAnonymousId(m.AnonymousId)
 		m.Context = makeContext(m.Context)
 		m.Channel = "server"
@@ -224,6 +228,7 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Type = "screen"
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.OriginalTimestamp = makeTimestamp(m.OriginalTimestamp, ts)
+		m.SentAt = m.OriginalTimestamp
 		m.AnonymousId = makeAnonymousId(m.AnonymousId)
 		m.Context = makeContext(m.Context)
 		m.Channel = "server"
@@ -233,6 +238,7 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Type = "track"
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.OriginalTimestamp = makeTimestamp(m.OriginalTimestamp, ts)
+		m.SentAt = m.OriginalTimestamp
 		m.AnonymousId = makeAnonymousId(m.AnonymousId)
 		m.Context = makeContext(m.Context)
 		m.Channel = "server"
@@ -371,7 +377,7 @@ func (c *client) send(msgs []message, retryAttempt int) {
 
 	ts := c.now()
 	for i := range msgs {
-		err := msgs[i].setSentAt(ts, c.MaxMessageBytes)
+		err := msgs[i].setSentAt(ts)
 		if err != nil {
 			c.errorf("%s - %v", err, msgs[i].msg)
 			c.notifyFailure([]message{msgs[i]}, err)

--- a/analytics.go
+++ b/analytics.go
@@ -190,7 +190,6 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Type = "alias"
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.OriginalTimestamp = makeTimestamp(m.OriginalTimestamp, ts)
-		m.SentAt = m.OriginalTimestamp
 		m.Context = makeContext(m.Context)
 		m.Channel = "server"
 		msg = m
@@ -199,7 +198,6 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Type = "group"
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.OriginalTimestamp = makeTimestamp(m.OriginalTimestamp, ts)
-		m.SentAt = m.OriginalTimestamp
 		m.AnonymousId = makeAnonymousId(m.AnonymousId)
 		m.Context = makeContext(m.Context)
 		m.Channel = "server"
@@ -209,7 +207,6 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Type = "identify"
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.OriginalTimestamp = makeTimestamp(m.OriginalTimestamp, ts)
-		m.SentAt = m.OriginalTimestamp
 		m.Context = makeContext(m.Context)
 		m.Channel = "server"
 		msg = m
@@ -218,7 +215,6 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Type = "page"
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.OriginalTimestamp = makeTimestamp(m.OriginalTimestamp, ts)
-		m.SentAt = m.OriginalTimestamp
 		m.AnonymousId = makeAnonymousId(m.AnonymousId)
 		m.Context = makeContext(m.Context)
 		m.Channel = "server"
@@ -228,7 +224,6 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Type = "screen"
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.OriginalTimestamp = makeTimestamp(m.OriginalTimestamp, ts)
-		m.SentAt = m.OriginalTimestamp
 		m.AnonymousId = makeAnonymousId(m.AnonymousId)
 		m.Context = makeContext(m.Context)
 		m.Channel = "server"
@@ -238,7 +233,6 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.Type = "track"
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.OriginalTimestamp = makeTimestamp(m.OriginalTimestamp, ts)
-		m.SentAt = m.OriginalTimestamp
 		m.AnonymousId = makeAnonymousId(m.AnonymousId)
 		m.Context = makeContext(m.Context)
 		m.Channel = "server"
@@ -374,6 +368,15 @@ func (c *client) getMarshalled(msgs []message) ([]byte, error) {
 // Send batch request.
 func (c *client) send(msgs []message, retryAttempt int) {
 	const attempts = 10
+
+	ts := c.now()
+	for i := range msgs {
+		err := msgs[i].setSentAt(ts, c.MaxMessageBytes)
+		if err != nil {
+			c.errorf("%s - %v", err, msgs[i].msg)
+			c.notifyFailure([]message{msgs[i]}, err)
+		}
+	}
 
 	nodePayload := c.getNodePayload(msgs)
 	for k, b := range nodePayload {

--- a/fixtures/test-timestamp-track.json
+++ b/fixtures/test-timestamp-track.json
@@ -9,7 +9,7 @@
         "version": "1.1.0"
       },
       "originalTimestamp": "2015-07-10T23:00:00Z",
-      "sentAt": "2015-07-10T23:00:00Z",
+      "sentAt": "2009-11-10T23:00:00Z",
       "type": "track",
       "userId": "123456",
       "anonymousId": "789012",

--- a/message.go
+++ b/message.go
@@ -85,7 +85,7 @@ func (m message) MarshalJSON() ([]byte, error) {
 }
 
 // setSentAt remarshalls the message with a new sentAt timestamp
-func (m *message) setSentAt(ts time.Time, maxBytes int) (err error) {
+func (m *message) setSentAt(ts time.Time) (err error) {
 	switch msg := m.msg.(type) {
 	case Alias:
 		msg.SentAt = ts
@@ -110,11 +110,7 @@ func (m *message) setSentAt(ts time.Time, maxBytes int) (err error) {
 		return
 	}
 
-	if m.json, err = json.Marshal(m.msg); err == nil {
-		if len(m.json) > maxBytes {
-			err = ErrMessageTooBig
-		}
-	}
+	m.json, err = json.Marshal(m.msg)
 	return
 }
 

--- a/message.go
+++ b/message.go
@@ -2,6 +2,7 @@ package analytics
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -81,6 +82,40 @@ func makeMessage(m Message, maxBytes int) (msg message, err error) {
 
 func (m message) MarshalJSON() ([]byte, error) {
 	return m.json, nil
+}
+
+// setSentAt remarshalls the message with a new sentAt timestamp
+func (m *message) setSentAt(ts time.Time, maxBytes int) (err error) {
+	switch msg := m.msg.(type) {
+	case Alias:
+		msg.SentAt = ts
+		m.msg = msg
+	case Group:
+		msg.SentAt = ts
+		m.msg = msg
+	case Identify:
+		msg.SentAt = ts
+		m.msg = msg
+	case Page:
+		msg.SentAt = ts
+		m.msg = msg
+	case Screen:
+		msg.SentAt = ts
+		m.msg = msg
+	case Track:
+		msg.SentAt = ts
+		m.msg = msg
+	default:
+		err = fmt.Errorf("messages with custom types cannot be enqueued: %T", msg)
+		return
+	}
+
+	if m.json, err = json.Marshal(m.msg); err == nil {
+		if len(m.json) > maxBytes {
+			err = ErrMessageTooBig
+		}
+	}
+	return
 }
 
 func (m message) size() int {


### PR DESCRIPTION
# Description

When `timestamp` is not specified, `timestamp` is computed as `timestamp = receivedAt - (sentAt - originalTimestamp)`. Currently this is handled incorrectly as `sentAt` was set to the same value `originalTimestamp` causing the computed `timestamp` to be `receivedAt`. Manually setting `originalTimestamp` was not functional as `sentAt` was still set to that value.

This PR makes the following changes
* Sets `sentAt` at batch-send time rather than at message-enqueue time so that the remote skew calculation works

This fixes #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced message sending functionality with timestamp tracking for improved message delivery reliability.
	- Introduced a method to update the `SentAt` timestamp for various message types, streamlining message management.

- **Bug Fixes**
	- Added error handling and notifications for failed message deliveries, ensuring better observability and reliability of the message-sending process. 

- **Chores**
	- Updated test data to reflect changes in timestamp handling for message events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->