### PR TITLE
chore: add DeepWiki badge to README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,8 @@
 
 <p align="center"><a href="https://github.com/rudderlabs/analytics-go"><img src="https://img.shields.io/github/v/release/rudderlabs/analytics-go.svg?label=Version"/></a></p>
 
+<p align="center"><a href="https://deepwiki.com/rudderlabs/analytics-go"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"/></a></p>
+
 ----
 
 # RudderStack Go SDK


### PR DESCRIPTION
## Summary

Add a DeepWiki badge to the README, linking to the DeepWiki page for `rudderlabs/analytics-go`. This gives contributors and users quick access to AI-powered documentation and code exploration for the repository.

## Changes

- Added a centered DeepWiki badge (`https://deepwiki.com/badge.svg`) to `Readme.md`, placed below the existing version badge.

## Test Plan

- [x] Verify the badge renders correctly in the GitHub README preview.
- [x] Verify the badge links to `https://deepwiki.com/rudderlabs/analytics-go`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a DeepWiki badge to the README file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->