### PR TITLE
feat: sdk-5290 improve go sdk context and version maintenance

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Version of the client.
-const Version = "4.2.3"
+const Version = "4.2.3" // x-release-please-version
 
 // This interface is the main API exposed by the analytics package.
 // Values that satsify this interface are returned by the client constructors

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -75,6 +75,8 @@ type testErrorMessage struct{}
 
 func (m testErrorMessage) Validate() error { return errorTest }
 
+const fixtureVersion = "__VERSION__"
+
 var (
 	// A control error returned by mock functions to emulate a failure.
 	errorTest = errors.New("test error")
@@ -143,7 +145,7 @@ func fixture(name string) string {
 	if err != nil {
 		panic(err)
 	}
-	return string(b)
+	return strings.ReplaceAll(string(b), `"`+fixtureVersion+`"`, `"`+Version+`"`)
 }
 
 func mockId() string { return "I'm unique" }
@@ -222,7 +224,8 @@ func ExampleTrack() {
 		},
 	})
 
-	fmt.Printf("%s\n", <-body)
+	result := strings.ReplaceAll(string(<-body), `"`+Version+`"`, `"`+fixtureVersion+`"`)
+	fmt.Printf("%s\n", result)
 	// Output:
 	// {
 	//   "batch": [
@@ -232,7 +235,7 @@ func ExampleTrack() {
 	//       "context": {
 	//         "library": {
 	//           "name": "analytics-go",
-	//           "version": "4.2.3"
+	//           "version": "__VERSION__"
 	//         }
 	//       },
 	//       "event": "Download",
@@ -249,6 +252,34 @@ func ExampleTrack() {
 	//     }
 	//   ]
 	// }
+}
+
+func TestClientReportsVersion(t *testing.T) {
+	userAgent := make(chan string, 1)
+	transport := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		userAgent <- r.UserAgent()
+		return testTransportOK.RoundTrip(r)
+	})
+
+	client, err := NewWithConfig(WRITE_KEY, Config{
+		Transport:   transport,
+		BatchSize:   1,
+		DisableGzip: true,
+	})
+	if err != nil {
+		t.Fatal("creating client:", err)
+	}
+	if err := client.Enqueue(Track{UserId: "user-123", Event: "Version Test"}); err != nil {
+		t.Fatal("enqueuing event:", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatal("closing client:", err)
+	}
+
+	expected := "analytics-go (version: " + Version + ")"
+	if actual := <-userAgent; actual != expected {
+		t.Errorf("invalid User-Agent: expected %q, received %q", expected, actual)
+	}
 }
 
 func TestEnqueue(t *testing.T) {

--- a/context.go
+++ b/context.go
@@ -22,6 +22,7 @@ type Context struct {
 	IP        net.IP       `json:"ip,omitempty"`
 	Direct    bool         `json:"direct,omitempty"`
 	Locale    string       `json:"locale,omitempty"`
+	GroupID   string       `json:"groupId,omitempty"`
 	Timezone  string       `json:"timezone,omitempty"`
 	UserAgent string       `json:"userAgent,omitempty"`
 	Traits    Traits       `json:"traits,omitempty"`

--- a/context_test.go
+++ b/context_test.go
@@ -34,3 +34,49 @@ func TestContextMarshalJSONExtra(t *testing.T) {
 		t.Error("invalid marshaled representation of context:", s)
 	}
 }
+
+func TestContextMarshalJSONGroupID(t *testing.T) {
+	tests := []struct {
+		name     string
+		context  Context
+		expected string
+	}{
+		{
+			name:     "typed group ID",
+			context:  Context{GroupID: "group-123"},
+			expected: `{"groupId":"group-123"}`,
+		},
+		{
+			name: "typed group ID takes precedence over extra",
+			context: Context{
+				GroupID: "typed-group",
+				Extra:   map[string]interface{}{"groupId": "extra-group"},
+			},
+			expected: `{"groupId":"typed-group"}`,
+		},
+		{
+			name: "extra group ID remains supported",
+			context: Context{
+				Extra: map[string]interface{}{"groupId": "extra-group"},
+			},
+			expected: `{"groupId":"extra-group"}`,
+		},
+		{
+			name:     "empty group ID is omitted",
+			context:  Context{},
+			expected: `{}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := json.Marshal(test.context)
+			if err != nil {
+				t.Fatal("marshalling context object failed:", err)
+			}
+			if actual := string(b); actual != test.expected {
+				t.Errorf("invalid marshaled representation: expected %s, received %s", test.expected, actual)
+			}
+		})
+	}
+}

--- a/fixtures/test-context-track.json
+++ b/fixtures/test-context-track.json
@@ -4,7 +4,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         },
         "whatever": "here"
       },

--- a/fixtures/test-enqueue-alias.json
+++ b/fixtures/test-enqueue-alias.json
@@ -10,7 +10,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       },
       "channel": "server"

--- a/fixtures/test-enqueue-group.json
+++ b/fixtures/test-enqueue-group.json
@@ -10,7 +10,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       },
       "channel": "server",

--- a/fixtures/test-enqueue-identify.json
+++ b/fixtures/test-enqueue-identify.json
@@ -9,7 +9,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       },
       "channel": "server"

--- a/fixtures/test-enqueue-page.json
+++ b/fixtures/test-enqueue-page.json
@@ -10,7 +10,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       },
       "channel": "server",

--- a/fixtures/test-enqueue-screen.json
+++ b/fixtures/test-enqueue-screen.json
@@ -10,7 +10,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       },
       "channel": "server",

--- a/fixtures/test-enqueue-track.json
+++ b/fixtures/test-enqueue-track.json
@@ -15,7 +15,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       },
       "anonymousId": "789012",

--- a/fixtures/test-integrations-track.json
+++ b/fixtures/test-integrations-track.json
@@ -22,7 +22,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       }
     }

--- a/fixtures/test-interval-track.json
+++ b/fixtures/test-interval-track.json
@@ -15,7 +15,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       },
       "anonymousId": "789012",

--- a/fixtures/test-many-track.json
+++ b/fixtures/test-many-track.json
@@ -16,7 +16,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       }
     },
@@ -36,7 +36,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       }
     },
@@ -56,7 +56,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       }
     }

--- a/fixtures/test-messageid-track.json
+++ b/fixtures/test-messageid-track.json
@@ -17,7 +17,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       }
     }

--- a/fixtures/test-timestamp-track.json
+++ b/fixtures/test-timestamp-track.json
@@ -17,7 +17,7 @@
       "context": {
         "library": {
           "name": "analytics-go",
-          "version": "4.2.3"
+          "version": "__VERSION__"
         }
       }
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -39,7 +39,13 @@
   "packages": {
     ".": {
       "package-name": "analytics-go",
-      "release-type": "go"
+      "release-type": "go",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "analytics.go"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- add typed `Context.GroupID` support while preserving `Context.Extra` compatibility
- cover serialization, omission, and precedence behavior
- centralize fixture and example version expectations on the SDK `Version` constant
- assert the version reported through the HTTP `User-Agent`
- configure release-please to update the SDK version source

## Why

The typed context field improves API discoverability without changing existing payloads. The version changes reduce repeated release edits and prevent fixture or header version drift.

## Impact

The public field addition is backward-compatible and should produce a minor SDK release. Existing callers that use `Context.Extra["groupId"]` remain supported.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `make lint`
- standalone Go consumer harness with a local module replacement
- live development-workspace E2E: 7/7 SDK operations and 7/7 Webhook deliveries passed

## References

- [SDK-5290](https://linear.app/rudderstack/issue/SDK-5290/improve-go-sdk-context-support-and-release-test-maintenance)
- [Go SDK maintenance analysis](https://app.notion.com/p/3bcf2b415dd0811c900efe97440731ea?pvs=204)
